### PR TITLE
Handle arm64 dev build for m1 mac

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,16 @@
 ARG python_version=3.8
 
 FROM python:${python_version} as builder
-
 # netifaces doesn't have wheels built for Python >3.6; build it ourselves
 # and then install in the next stage.
 # yappi also doesn't have any wheel built.
-RUN pip wheel netifaces --wheel-dir /custom-wheels \
-  https://github.com/al45tair/netifaces/archive/release_0_10_9.tar.gz \
-  https://files.pythonhosted.org/packages/4c/18/1b9387c7d3bf0d7aa54773ded7d286bcb8b04ec242404969f6656a385a11/yappi-1.3.2.tar.gz
+# Added wheel for psutil to make ARM64 happy
+
+RUN pip wheel \
+  --wheel-dir /custom-wheels \
+  netifaces \
+  yappi \
+  psutil
 
 FROM python:${python_version}-slim as base
 
@@ -28,8 +31,7 @@ ADD pyproject.toml .
 # This is not hard-coded in the pyproject.toml so that poetry can still
 # be used on the host machine, which won't have this .wheels directory.
 RUN poetry add \
-  .wheels/netifaces-0.10.9-cp38-cp38-linux_x86_64.whl \
-  .wheels/yappi-1.3.2-cp38-cp38-linux_x86_64.whl
+  .wheels/*
 
 RUN poetry install --no-dev
 


### PR DESCRIPTION
load wheels into poetry using shell glob. Can still specify explicit
versions on wheel creation.

More generic pattern may be to build venv in "fat" environment, then
copy to runtime image. Alternately, use poetry export to generate
requirements file, and install using pip in final image.