### PR TITLE
fix GH actions build and push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ name: build and push container
 on:
   push:
     branches:
+      - "**"
+    tags:
+      - "v*"
+  pull_request:
+    branches:
       - "main"
 
 jobs:
@@ -10,10 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_REGISTRY: docker.chameleoncloud.org
-      DOCKER_IMAGE: $(DOCKER_REGISTRY)/doni:latest
+      DOCKER_IMAGE: docker.chameleoncloud.org/doni
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tag-sha: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
@@ -24,6 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
       - name: Login to Chameleon Repo
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
@@ -34,8 +46,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: true
-          tags: ${{ env.DOCKER_IMAGE }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,10 @@ jobs:
           logout: true
       - name: Build and push
         uses: docker/build-push-action@v2
+        id: docker_build
         with:
           context: .
+          file: ./docker/Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
@@ -58,3 +60,5 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Print Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
image tag was failing from invalid syntax.
Use recommended action to generate tags programatically.

It will use the git short-hash on all images.
If triggered by a git tag, it will add the tag name, and latest.

the behavior here is to build on all push events, all PRs to main, and all tag events.
How "liberal" we want to be here depends on pruning our registry.

It will only `docker push` on a non-PR event, so git pushes and tags.

refer to https://github.com/crazy-max/ghaction-docker-meta for examples of easy use of semver in naming.

the repo for docker's GH actions has an example here: https://github.com/docker/build-push-action/blob/master/docs/advanced/tags-labels.md