### PR TITLE
Feature/export endpoint

### DIFF
--- a/doni/api/hardware.py
+++ b/doni/api/hardware.py
@@ -138,6 +138,7 @@ def get_all():
         "hardware": [serialize(hw) for hw in Hardware.list(ctx)],
     }
 
+
 @route("/export/", methods=["GET"], blueprint=bp)
 def export():
     ctx = request.context

--- a/doni/api/hardware.py
+++ b/doni/api/hardware.py
@@ -140,10 +140,7 @@ def get_all():
 
 @route("/export/", methods=["GET"], blueprint=bp)
 def export():
-    # ctx = request.context
-    # what should the shape of the data
-    # test to make sure private fields not returned
-    # make an anonymoyus request # check authorize calls should fail
+    ctx = request.context
     serialize = hardware_serializer(with_private_fields=False)
     return {
         "hardware": [serialize(hw) for hw in Hardware.list(ctx)],

--- a/doni/api/hardware.py
+++ b/doni/api/hardware.py
@@ -1,33 +1,39 @@
-from flask import Blueprint
-from flask import request
-
-from doni.api.hooks import route
 from doni.api import utils as api_utils
-from doni.common import args
-from doni.common import driver_factory
+from doni.api.hooks import route
+from doni.common import args, driver_factory
 from doni.common.policy import authorize
 from doni.objects import transaction
 from doni.objects.availability_window import AvailabilityWindow
 from doni.objects.hardware import Hardware
 from doni.objects.worker_task import WorkerTask
 from doni.worker import WorkerField
+from flask import Blueprint, request
 
 bp = Blueprint("hardware", __name__)
 
 
-DEFAULT_FIELDS = ('name', 'project_id', 'hardware_type', 'properties',)
-WORKER_TASK_DEFAULT_FIELDS = ('worker_type', 'state', 'state_details',)
+DEFAULT_FIELDS = (
+    "name",
+    "project_id",
+    "hardware_type",
+    "properties",
+)
+WORKER_TASK_DEFAULT_FIELDS = (
+    "worker_type",
+    "state",
+    "state_details",
+)
 
 HARDWARE_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        'name': args.STRING,
-        'uuid': args.STRING,
-        'hardware_type': args.STRING,
-        'project_id': args.STRING,
-        'properties': {'type': 'object', 'additionalProperties': True},
+    "type": "object",
+    "properties": {
+        "name": args.STRING,
+        "uuid": args.STRING,
+        "hardware_type": args.STRING,
+        "project_id": args.STRING,
+        "properties": {"type": "object", "additionalProperties": True},
     },
-    'additionalProperties': False,
+    "additionalProperties": False,
 }
 
 
@@ -39,14 +45,8 @@ def hardware_validator():
     for hwt_name, hwt in enabled_hardware_types.items():
         properties_schema = {
             "type": "object",
-            "properties": {
-                field.name: field.schema
-                for field in hwt.default_fields
-            },
-            "required": [
-                field.name for field in hwt.default_fields
-                if field.required
-            ],
+            "properties": {field.name: field.schema for field in hwt.default_fields},
+            "required": [field.name for field in hwt.default_fields if field.required],
             # Disallow keys that don't match any worker
             "additionalProperties": False,
         }
@@ -61,24 +61,24 @@ def hardware_validator():
         if not properties_schema["required"]:
             del properties_schema["required"]
 
-        hardware_type_schemas.append({
-            "type": "object",
-            "properties": {
-                "hardware_type": {"const": hwt_name},
-                "properties": properties_schema,
+        hardware_type_schemas.append(
+            {
+                "type": "object",
+                "properties": {
+                    "hardware_type": {"const": hwt_name},
+                    "properties": properties_schema,
+                },
             }
-        })
+        )
 
     schema = {
-        "definitions": {
-            "hardware": HARDWARE_SCHEMA
-        },
+        "definitions": {"hardware": HARDWARE_SCHEMA},
         "allOf": [
             # Check base hardware schema
             {"$ref": "#/definitions/hardware"},
             # Check schema for hardware types
             {"oneOf": hardware_type_schemas},
-        ]
+        ],
     }
 
     return args.schema(schema)
@@ -121,7 +121,8 @@ def hardware_serializer(with_private_fields=False):
                     # Don't serialize 'None'
                     continue
                 filtered_properties[field.name] = (
-                    _mask_sensitive(value) if field.sensitive else value)
+                    _mask_sensitive(value) if field.sensitive else value
+                )
 
         hardware_json["properties"] = filtered_properties
         return hardware_json
@@ -147,6 +148,7 @@ def export():
         "hardware": [serialize(hw) for hw in Hardware.list(ctx)],
     }
 
+
 @route("/<hardware_uuid>/", methods=["GET"], blueprint=bp)
 @args.validate(hardware_uuid=args.uuid)
 def get_one(hardware_uuid=None):
@@ -161,7 +163,7 @@ def get_one(hardware_uuid=None):
             include_created_at=False,
             include_updated_at=False,
             include_uuid=False,
-            fields=WORKER_TASK_DEFAULT_FIELDS
+            fields=WORKER_TASK_DEFAULT_FIELDS,
         )
         for wt in WorkerTask.list_for_hardware(ctx, hardware_uuid)
     ]
@@ -207,7 +209,8 @@ def update(hardware_uuid=None, patch=None):
 
         if "availability" in patched_state:
             to_add, to_update, to_remove = api_utils.apply_patch_updates_to_list(
-                state["availability"], patched_state["availability"])
+                state["availability"], patched_state["availability"]
+            )
             for window in to_add:
                 window.create()
             for window in to_update:

--- a/doni/api/hardware.py
+++ b/doni/api/hardware.py
@@ -138,6 +138,16 @@ def get_all():
         "hardware": [serialize(hw) for hw in Hardware.list(ctx)],
     }
 
+@route("/export/", methods=["GET"], blueprint=bp)
+def export():
+    # ctx = request.context
+    # what should the shape of the data
+    # test to make sure private fields not returned
+    # make an anonymoyus request # check authorize calls should fail
+    serialize = hardware_serializer(with_private_fields=False)
+    return {
+        "hardware": [serialize(hw) for hw in Hardware.list(ctx)],
+    }
 
 @route("/<hardware_uuid>/", methods=["GET"], blueprint=bp)
 @args.validate(hardware_uuid=args.uuid)

--- a/doni/api/hooks.py
+++ b/doni/api/hooks.py
@@ -35,7 +35,7 @@ class AuthTokenFlaskMiddleware(object):
     def before_request(self):
         # skip on public routes
         # TODO this is ugly.
-        if request.path == '/v1/hardware/export/':
+        if request.path == "/v1/hardware/export/":
             return
 
         # When the middleware is invoked, it should mutate request.environ

--- a/doni/api/hooks.py
+++ b/doni/api/hooks.py
@@ -1,17 +1,16 @@
 from functools import wraps
+from typing import TYPE_CHECKING
 
+from doni.api.utils import make_error_response
+from doni.common import context as doni_context
+from doni.common import exception
+from doni.conf import CONF
 from flask import request
 from keystonemiddleware.auth_token import AuthProtocol
 from keystonemiddleware.auth_token._request import _AuthTokenRequest
 from oslo_log import log
 from oslo_policy.policy import PolicyNotAuthorized
 
-from doni.api.utils import make_error_response
-from doni.common import context as doni_context
-from doni.common import exception
-from doni.conf import CONF
-
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from flask import Blueprint
 
@@ -27,10 +26,14 @@ class AuthTokenFlaskMiddleware(object):
     choices around how middleware are handled. This class just wraps up the
     middleware exposed by auth_token such that Flask can use it.
     """
+
     def __init__(self):
-        self.keystonemiddleware = AuthProtocol(None, {
-            "oslo_config_config": CONF,
-        })
+        self.keystonemiddleware = AuthProtocol(
+            None,
+            {
+                "oslo_config_config": CONF,
+            },
+        )
 
     def before_request(self):
         # skip on public routes
@@ -47,7 +50,8 @@ class AuthTokenFlaskMiddleware(object):
             # NOTE: we have to cast to a dict structure because `headers` is
             # wrapped in a Flask/werkzeug data structure, and webob doesn't
             # properly interpret it as headers to be set in this form.
-            headers=dict(request.headers))
+            headers=dict(request.headers),
+        )
         res = self.keystonemiddleware.process_request(auth_token_request)
         if res:
             return res
@@ -55,15 +59,14 @@ class AuthTokenFlaskMiddleware(object):
 
 class ContextMiddleware(object):
     def before_request(self):
-        request.context = (
-            doni_context.RequestContext.from_environ(request.environ))
+        request.context = doni_context.RequestContext.from_environ(request.environ)
 
     def after_request(self, res):
         res.headers["OpenStack-Request-Id"] = request.context.request_id
         return res
 
 
-def route(rule, blueprint: "Blueprint"=None, json_body=None, **options):
+def route(rule, blueprint: "Blueprint" = None, json_body=None, **options):
     """Decorator which exposes a function as a Flask handler and handles errors.
 
     This is essentially a combination of Flask's default ``route`` decorator
@@ -84,6 +87,7 @@ def route(rule, blueprint: "Blueprint"=None, json_body=None, **options):
         A decorated handler function, which is registered on the Flask
             blueprint and will translate known exceptions to HTTP status codes.
     """
+
     def inner_function(function):
         @wraps(function)
         def inner_check_args(*args, **kwargs):
@@ -100,8 +104,11 @@ def route(rule, blueprint: "Blueprint"=None, json_body=None, **options):
             except Exception as exc:
                 # FIXME: why won't this log for tests and we have to print()?
                 import traceback
+
                 traceback.print_exc()
                 LOG.error(f"Unhandled error on {rule}: {exc}")
                 return make_error_response("An unknown error occurred.", 500)
+
         return blueprint.route(rule, **options)(inner_check_args)
+
     return inner_function

--- a/doni/api/hooks.py
+++ b/doni/api/hooks.py
@@ -33,6 +33,11 @@ class AuthTokenFlaskMiddleware(object):
         })
 
     def before_request(self):
+        # skip on public routes
+        # TODO this is ugly.
+        if request.path == '/v1/hardware/export/':
+            return
+
         # When the middleware is invoked, it should mutate request.environ
         # and add 'keystone.auth_token' and 'keystone.auth_plugin' attributes.
         auth_token_request = _AuthTokenRequest(

--- a/doni/driver/worker/fake.py
+++ b/doni/driver/worker/fake.py
@@ -1,8 +1,7 @@
-from doni.worker import BaseWorker
-from doni.worker import WorkerField
-from doni.worker import WorkerResult
-
 from typing import TYPE_CHECKING
+
+from doni.worker import BaseWorker, WorkerField, WorkerResult
+
 if TYPE_CHECKING:
     from doni.common.context import RequestContext
     from doni.objects.hardware import Hardware
@@ -17,8 +16,10 @@ class FakeWorker(BaseWorker):
         WorkerField("public-and-sensitive-field", private=False, sensitive=True),
     ]
 
-    def process(self, context: "RequestContext", hardware: "Hardware") -> "WorkerResult.Base":
+    def process(
+        self, context: "RequestContext", hardware: "Hardware"
+    ) -> "WorkerResult.Base":
         print(f"fake: processing hardware {hardware.uuid}")
-        return WorkerResult.Success({
-            "fake-result": f"fake-worker-prefix-{hardware.uuid}"
-        })
+        return WorkerResult.Success(
+            {"fake-result": f"fake-worker-prefix-{hardware.uuid}"}
+        )

--- a/doni/driver/worker/fake.py
+++ b/doni/driver/worker/fake.py
@@ -13,7 +13,8 @@ class FakeWorker(BaseWorker):
     fields = [
         WorkerField("private-field", private=True),
         WorkerField("private-and-sensitive-field", private=True, sensitive=True),
-        WorkerField("sensitive-field", sensitive=True),
+        WorkerField("public-field", private=False),
+        WorkerField("public-and-sensitive-field", private=False, sensitive=True),
     ]
 
     def process(self, context: "RequestContext", hardware: "Hardware") -> "WorkerResult.Base":

--- a/doni/tests/unit/api/test_export.py
+++ b/doni/tests/unit/api/test_export.py
@@ -1,8 +1,6 @@
-from flask.testing import FlaskClient
-
-from doni.tests.unit import utils
-
 import pytest
+from doni.tests.unit import utils
+from flask.testing import FlaskClient
 
 
 def _test_validate_export(res):

--- a/doni/tests/unit/api/test_export.py
+++ b/doni/tests/unit/api/test_export.py
@@ -1,0 +1,21 @@
+from flask.testing import FlaskClient
+
+from doni.tests.unit import utils
+
+
+def test_export_hardware(
+    mocker, user_auth_headers, client: "FlaskClient", database: "utils.DBFixtures"
+):
+    mock_authorize = mocker.patch("doni.api.hardware.authorize")
+    hw = database.add_hardware()
+    res = client.get(f"/v1/hardware/export/", headers=user_auth_headers)
+    assert res.status_code == 200
+
+    # What should this retun
+    # assert res.json == {
+    #     "availability": [],
+    # }
+
+    assert mock_authorize.called_once_with("hardware:get")
+    print(mock_authorize.calls)
+    raise Exception

--- a/doni/tests/unit/utils.py
+++ b/doni/tests/unit/utils.py
@@ -29,8 +29,9 @@ def get_test_hardware(**kw):
         "project_id": kw.get("project_id", "fake_project_id"),
         "properties": kw.get("properties", {
             "private-field": "fake-private-field",
-            "sensitive-field": "fake-sensitive-field",
             "private-and-sensitive-field": "fake-private-and-sensitive-field",
+            "public-field": "fake-public-field",
+            "public-and-sensitive-field": "fake-public-and-sensitive-field",
         }),
     }
 

--- a/doni/tests/unit/utils.py
+++ b/doni/tests/unit/utils.py
@@ -1,14 +1,12 @@
 """Doni test utilities."""
 
-from oslo_utils import uuidutils
-from stevedore import extension
-from stevedore import named
-
-from doni.common import driver_factory
-from doni.common import exception
-from doni.db import api as db_api
-
 from typing import TYPE_CHECKING
+
+from doni.common import driver_factory, exception
+from doni.db import api as db_api
+from oslo_utils import uuidutils
+from stevedore import extension, named
+
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
@@ -27,16 +25,19 @@ def get_test_hardware(**kw):
         "uuid": kw.get("uuid", default_uuid),
         "hardware_type": kw.get("hardware_type", FAKE_HARDWARE_TYPE),
         "project_id": kw.get("project_id", "fake_project_id"),
-        "properties": kw.get("properties", {
-            "private-field": "fake-private-field",
-            "private-and-sensitive-field": "fake-private-and-sensitive-field",
-            "public-field": "fake-public-field",
-            "public-and-sensitive-field": "fake-public-and-sensitive-field",
-        }),
+        "properties": kw.get(
+            "properties",
+            {
+                "private-field": "fake-private-field",
+                "private-and-sensitive-field": "fake-private-and-sensitive-field",
+                "public-field": "fake-public-field",
+                "public-and-sensitive-field": "fake-public-and-sensitive-field",
+            },
+        ),
     }
 
 
-def mock_drivers(mocker: "MockerFixture", namespaces: dict=None):
+def mock_drivers(mocker: "MockerFixture", namespaces: dict = None):
     """Mock out drivers dynamically included via entry_points.
 
     This can be used to create one-off test drivers for hardware types or
@@ -63,8 +64,7 @@ def mock_drivers(mocker: "MockerFixture", namespaces: dict=None):
 
         drivers = namespaces[_namespace]
         extensions = [
-            extension.Extension(
-                name, entry_point=None, plugin=driver_class, obj=None)
+            extension.Extension(name, entry_point=None, plugin=driver_class, obj=None)
             for name, driver_class in drivers.items()
             # The caller will specify an allowlist of names to add to the
             # extension manager; ensure we respect this.
@@ -72,8 +72,8 @@ def mock_drivers(mocker: "MockerFixture", namespaces: dict=None):
         ]
         on_load_failure_callback = kwargs["on_load_failure_callback"]
         em = named.NamedExtensionManager.make_test_instance(
-            extensions, _namespace,
-            on_load_failure_callback=on_load_failure_callback)
+            extensions, _namespace, on_load_failure_callback=on_load_failure_callback
+        )
         # NOTE(jason): ``make_test_instance`` doesn't actually do anything with
         # the on_load_failure_callback, nor does it attempt to invoke the
         # entrypoints. So, we do a kludgy mimicry of this here.
@@ -84,13 +84,14 @@ def mock_drivers(mocker: "MockerFixture", namespaces: dict=None):
                 on_load_failure_callback(em, ext, exc)
         return em
 
-    (mocker.patch("doni.common.driver_factory._create_extension_manager")
-        .side_effect) = _create_extension_manager
+    (
+        mocker.patch("doni.common.driver_factory._create_extension_manager").side_effect
+    ) = _create_extension_manager
 
 
 class DBFixtures(object):
-    """A helper utility for setting up test data in the test DB.
-    """
+    """A helper utility for setting up test data in the test DB."""
+
     def __init__(self):
         self.db = db_api.get_instance()
         self._hardwares = []
@@ -123,11 +124,9 @@ class DBFixtures(object):
         Raises:
             ValueError: if a Hardware could not be found for the UUID.
         """
-        hw = next(
-            (hw for hw in self._hardwares if hw.uuid == hardware_uuid), None)
+        hw = next((hw for hw in self._hardwares if hw.uuid == hardware_uuid), None)
         if not hw:
-            raise ValueError(
-                f"Could not find Hardware {hardware_uuid} to delete")
+            raise ValueError(f"Could not find Hardware {hardware_uuid} to delete")
         self.db.destroy_hardware(hw.uuid)
         self._hardwares.remove(hw)
 
@@ -147,6 +146,7 @@ class DBFixtures(object):
 
 class MockResponse:
     """A simple class for mocking HTTP responses."""
+
     def __init__(self, status_code, body=None):
         self.status_code = status_code
         self.body = body

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@
 line-length = 88
 
 [tool.poetry]
-authors = [
-  "Jason Anderson <jasonanderson@uchicago.edu>"
-]
+authors = ["Jason Anderson <jasonanderson@uchicago.edu>"]
 description = "Chameleon hardware registration and enrollment service"
 name = "doni"
 version = "0.0.1"


### PR DESCRIPTION
Add the public export endpoint.

Intended behavior is that a list of all hardware in the system will be returned as a json object.
Fields returned should include:

- Date Created
- Date Last Updated
- UUID
- Human Readable Name
- Hardware Type
- Project ID  that provided / owns the hardware (usually the site operator)
- And any public properties defined on the items. This would exclude things like IPMI credentials, license keys, and so on.