### PR TITLE
Feature/blazar sync worker

### DIFF
--- a/doni/driver/worker/blazar.py
+++ b/doni/driver/worker/blazar.py
@@ -146,7 +146,7 @@ def _search_leases_for_lease_id(existing_leases: dict, new_lease: dict) -> tuple
 
 
 class BlazarPhysicalHostWorker(BaseWorker):
-    """This class handles the syncronization of physical hosts from Doni to Blazar."""
+    """This class handles the synchronization of physical hosts from Doni to Blazar."""
 
     opts = []
     opt_group = "blazar"
@@ -187,7 +187,7 @@ class BlazarPhysicalHostWorker(BaseWorker):
             else:
                 raise  # Unhandled exception
         else:
-            # On sucess, cache host_id and updated time
+            # On success, cache host_id and updated time
             result["blazar_host_id"] = blazar_host.get("id")
             result["host_updated_at"] = blazar_host.get("updated_at")
             return WorkerResult.Success(result)

--- a/doni/driver/worker/blazar.py
+++ b/doni/driver/worker/blazar.py
@@ -245,6 +245,24 @@ class BlazarPhysicalHostWorker(BaseWorker):
 
         return WorkerResult.Success(result)
 
+    def import_existing(self, context: "RequestContext"):
+        existing_hosts = _call_blazar(context, "/os-hosts")["hosts"]
+        for host in existing_hosts:
+            existing_hosts.append(
+                {
+                    "uuid": host["hypervisor_hostname"],
+                    "name": host.get("node_name"),
+                    "properties": {
+                        "node_type": host.get("node_type"),
+                        "placement": {
+                            "node": host.get("placement.node"),
+                            "rack": host.get("placement.rack"),
+                        },
+                    },
+                }
+            )
+        return existing_hosts
+
 
 def _call_blazar(context, path, method="get", json=None, allowed_status_codes=[]):
     try:

--- a/doni/driver/worker/blazar.py
+++ b/doni/driver/worker/blazar.py
@@ -1,20 +1,119 @@
+from textwrap import shorten
 from typing import TYPE_CHECKING
 
-from doni.worker import BaseWorker
+from keystoneauth1 import exceptions as kaexception
+from oslo_log import log
+
+from doni.common import args, exception, keystone
+from doni.conf import auth as auth_conf
+from doni.worker import BaseWorker, WorkerResult
 
 if TYPE_CHECKING:
     from doni.common.context import RequestContext
     from doni.objects.availability_window import AvailabilityWindow
     from doni.objects.hardware import Hardware
-    from doni.worker import WorkerResult
+
+
+LOG = log.getLogger(__name__)
+
+BLAZAR_API_VERSION = "1"
+BLAZAR_API_MICROVERSION = "1.0"
+_BLAZAR_ADAPTER = None
+
+
+def _get_blazar_adapter():
+    global _BLAZAR_ADAPTER
+    if not _BLAZAR_ADAPTER:
+        _BLAZAR_ADAPTER = keystone.get_adapter(
+            "blazar",
+            session=keystone.get_session("blazar"),
+            auth=keystone.get_auth("blazar"),
+            version=BLAZAR_API_VERSION,
+        )
+    return _BLAZAR_ADAPTER
+
+
+class BlazarUnavailable(exception.DoniException):
+    _msg_fmt = (
+        "Could not contact Blazar API. Please check the service "
+        "configuration. The precise error was: %(message)s"
+    )
+
+
+class BlazarAPIError(exception.DoniException):
+    _msg_fmt = "Blazar responded with HTTP %(code)s: %(text)s"
+
+
+class BlazarAPIMalformedResponse(exception.DoniException):
+    _msg_fmt = "Blazar response malformed: %(text)s"
+
+
+class BlazarNodeProvisionStateTimeout(exception.DoniException):
+    _msg_fmt = (
+        "Blazar node %(node)s timed out updating its provision state to %(state)s"
+    )
 
 
 class BlazarPhysicalHostWorker(BaseWorker):
+    opts = []
+    opt_group = "blazar"
+
+    def register_opts(self, conf):
+        conf.register_opts(self.opts, group=self.opt_group)
+        auth_conf.register_auth_opts(conf, self.opt_group, service_type="reservation")
+
+    def list_opts(self):
+        return auth_conf.add_auth_opts(self.opts, service_type="reservation")
+
     def process(
         self,
         context: "RequestContext",
         hardware: "Hardware",
         availability_windows: "list[AvailabilityWindow]" = None,
-        state_details: "dict" = None,
+        state_details: "dict" = {},
     ) -> "WorkerResult.Base":
-        pass
+
+        host_id = state_details.get("blazar_host_id")
+
+        desired_state = {
+            # what data does blazar contain
+            "name": "compute-1",
+            "extra_capability_sample": "foo",
+        }
+
+        request_body = desired_state
+
+        if host_id:
+            existing = _call_blazar(
+                context,
+                f"/os-hosts/{host_id}",
+                method="get",
+                allowed_status_codes=[404],
+            )
+        else:
+            host = _call_blazar(context, f"/os-hosts", method="post", json=request_body)
+            return WorkerResult.Success({"created_at": host["created_at"]})
+
+
+def _call_blazar(context, path, method="get", json=None, allowed_status_codes=[]):
+    try:
+        blazar = _get_blazar_adapter()
+        resp = blazar.request(
+            path,
+            method=method,
+            json=json,
+            microversion=BLAZAR_API_MICROVERSION,
+            global_request_id=context.global_id,
+            raise_exc=False,
+        )
+    except kaexception.ClientException as exc:
+        raise BlazarUnavailable(message=str(exc))
+
+    if resp.status_code >= 400 and resp.status_code not in allowed_status_codes:
+        raise BlazarAPIError(code=resp.status_code, text=shorten(resp.text, width=50))
+
+    try:
+        # Treat empty response bodies as None
+        return resp.json() if resp.text else None
+    except Exception:
+        raise BlazarAPIMalformedResponse(text=shorten(resp.text, width=50))

--- a/doni/driver/worker/blazar.py
+++ b/doni/driver/worker/blazar.py
@@ -121,7 +121,7 @@ class BlazarPhysicalHostWorker(BaseWorker):
                 f"/os-hosts",
                 method="post",
                 json=info_to_set,
-                allowed_status_codes=[201],
+                allowed_status_codes=[201, 409],
             )
             state_details["id"] = host.get("id")
             result["host_created_at"] = host.get("created_at")

--- a/doni/driver/worker/blazar.py
+++ b/doni/driver/worker/blazar.py
@@ -152,6 +152,7 @@ class BlazarPhysicalHostWorker(BaseWorker):
                     allowed_status_codes=[200],
                 )
                 result["host_updated_at"] = update.get("updated_at")
+                result["blazar_host_id"] = update.get("id")
             except BlazarAPIError as exc:
                 # TODO what error code does blazar return if the host has a lease already?
                 if exc.code == 404:
@@ -204,7 +205,7 @@ class BlazarPhysicalHostWorker(BaseWorker):
         # Loop over all availability windows for this hw item that Doni has
         for aw in availability_windows or []:
 
-            aw_dict = _aw_lease_dict(aw)
+            aw_dict = _blazar_lease_requst_body(aw)
             # Check to see if lease name already exists in blazar
             matching_lease = next(
                 (

--- a/doni/driver/worker/blazar.py
+++ b/doni/driver/worker/blazar.py
@@ -152,7 +152,6 @@ class BlazarPhysicalHostWorker(BaseWorker):
                     allowed_status_codes=[200],
                 )
                 result["host_updated_at"] = update.get("updated_at")
-                result["blazar_host_id"] = update.get("id")
             except BlazarAPIError as exc:
                 # TODO what error code does blazar return if the host has a lease already?
                 if exc.code == 404:

--- a/doni/tests/unit/driver/worker/test_blazar.py
+++ b/doni/tests/unit/driver/worker/test_blazar.py
@@ -1,0 +1,97 @@
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+from doni.driver.worker.blazar import BlazarPhysicalHostWorker
+from doni.objects.hardware import Hardware
+from doni.tests.unit import utils
+from doni.worker import WorkerResult
+from keystoneauth1 import loading as ks_loading
+from oslo_utils import uuidutils
+
+TEST_BLAZAR_HOST_ID = "1"
+TEST_HARDWARE_UUID = uuidutils.generate_uuid()
+
+if TYPE_CHECKING:
+    from doni.common.context import RequestContext
+
+
+@pytest.fixture
+def blazar_worker(test_config):
+    """Generate a test blazarWorker and ensure the environment is configured for it.
+
+    Much of this is black magic to appease the gods of oslo_config.
+    """
+    # Configure the app to use a hardware type valid for this worker.
+    test_config.config(
+        enabled_hardware_types=["baremetal"],
+        enabled_worker_types=["blazar.physical_host"],
+    )
+
+    worker = BlazarPhysicalHostWorker()
+    worker.register_opts(test_config)
+    # NOTE(jason):
+    # At application runtime, Keystone auth plugins are registered dynamically
+    # depending on what auth_type is provided in the config. I'm not sure how
+    # it's possible to even express that here, as there's a chicken-or-egg
+    # question of how you set the auth_type while it's registering all the
+    # auth options. So we register the manually here.
+    plugin = ks_loading.get_plugin_loader("v3password")
+    opts = ks_loading.get_auth_plugin_conf_options(plugin)
+    test_config.register_opts(opts, group=worker.opt_group)
+
+    test_config.config(
+        group="blazar",
+        auth_type="v3password",
+        auth_url="http://localhost:5000",
+        username="fake-username",
+        user_domain_name="fake-user-domain-name",
+        password="fake-password",
+        project_name="fake-project-name",
+        project_domain_name="fake-project-domain-name",
+    )
+    return worker
+
+
+def get_fake_hardware(database: "utils.DBFixtures"):
+    db_hw = database.add_hardware(
+        uuid=TEST_HARDWARE_UUID,
+        hardware_type="baremetal",
+        properties={
+            "baremetal_driver": "fake-driver",
+            "management_address": "fake-management_address",
+            "ipmi_username": "fake-ipmi_username",
+            "ipmi_password": "fake-ipmi_password",
+        },
+    )
+    return Hardware(**db_hw)
+
+
+def get_fake_blazar(mocker, request_fn):
+    mock_adapter = mock.MagicMock()
+    mock_request = mock_adapter.request
+    mock_request.side_effect = request_fn
+    mocker.patch(
+        "doni.driver.worker.blazar._get_blazar_adapter"
+    ).return_value = mock_adapter
+    return mock_request
+
+
+def test_create_new_physical_host(
+    mocker,
+    admin_context: "RequestContext",
+    blazar_worker: "BlazarWorker",
+    database: "utils.DBFixtures",
+):
+    def _fake_blazar_for_create(path, method=None, json=None, **kwargs):
+        if method == "get" and path == f"v1/os-hosts/{TEST_BLAZAR_HOST_ID}":
+            return utils.MockResponse(404)
+        elif method == "post" and path == f"/os-hosts":
+            assert json["name"] == "compute-1"
+            return utils.MockResponse(201, {"created_at": "fake-created_at"})
+        raise NotImplementedError("Unexpected request signature")
+
+    fake_blazar = get_fake_blazar(mocker, _fake_blazar_for_create)
+    result = blazar_worker.process(admin_context, get_fake_hardware(database), {})
+
+    assert isinstance(result, WorkerResult.Success)

--- a/doni/tests/unit/driver/worker/test_blazar.py
+++ b/doni/tests/unit/driver/worker/test_blazar.py
@@ -115,7 +115,7 @@ def _stub_blazar_host_new(path, method, json):
         assert json["node_name"] == "fake_name_1"
         return utils.MockResponse(201, {"created_at": "fake-created_at"})
     elif method == "get" and path == f"/leases":
-        return utils.MockResponse(200, {"leases": ["foo"]})
+        return utils.MockResponse(200, {"leases": []})
     else:
         return None
 
@@ -142,7 +142,7 @@ def _stub_blazar_host_exist(path, method, json, hw_list=None):
             409, {"created_at": "fake-created_at", "name": "{TEST_BLAZAR_HOST_ID}"}
         )
     elif method == "get" and path == f"/leases":
-        return utils.MockResponse(200, {"leases": ["bar"]})
+        return utils.MockResponse(200, {"leases": []})
     else:
         return None
 

--- a/doni/tests/unit/driver/worker/test_blazar.py
+++ b/doni/tests/unit/driver/worker/test_blazar.py
@@ -98,7 +98,7 @@ def test_create_new_physical_host(
             return utils.MockResponse(404)
         elif method == "post" and path == f"/os-hosts":
             # assume that creation succeeds, return created time
-            assert json["name"] == "compute-1"
+            assert json["node_name"] == "fake_name_1"
             return utils.MockResponse(201, {"created_at": "fake-created_at"})
         raise NotImplementedError("Unexpected request signature")
 
@@ -127,7 +127,7 @@ def test_update_existing_physical_host(
             return utils.MockResponse(200)
         elif method == "put" and path == f"/os-hosts/{TEST_BLAZAR_HOST_ID}":
             # assume that creation succeeds, return created time
-            assert json["name"] == "compute-1"
+            assert json["node_name"] == "fake_name_1"
             return utils.MockResponse(201, {"updated_at": "fake-updated_at"})
         raise NotImplementedError("Unexpected request signature")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+filterwarnings = ["ignore::DeprecationWarning"]
 
 [tool.isort]
 known_first_party = "doni"


### PR DESCRIPTION
This PR ensures that an up-to-date blazar host exists for each physical host in Doni's DB.

To avoid expensive lookups, it caches the mapping from `blazar_host_id` to `hardware_uuid` in the `state_details` of the task. Otherwise, we can only discover this mapping by listing all hosts, then searching for the matching hardware_uuid.

If the `blazar_host_id` is not present, we assume that the host must be created. In the case that the host already exists, the worker will search for the host, and add its ID to the cache.

On Duplicate detection:
We assume that `hardware_uuid` is unique, and use it to detect several failure cases in blazar's logic.
The `name` field is used by Blazar to check the status of the host in nova, and thus ironic. Our convention is to have `name == hardware_uuid`, so we continue that here. Blazar checks for 3 cases: Missing, Present, and Multiple.

In the "Missing" case, we defer, as the Ironic worker must complete before this one.
The "Present" case is the "base" case, and host creation proceeds normally.
The "Multiple" case is an error state, but ironic should usually prevent this from occurring.

If the `blazar_host_id` is present, we assume the "update" case.
We unconditionally update, rather than `GET` + `UPDATE`, to reduce the number of calls.

If the host cannot be updated due to a conflict, we detect a `409` and defer.
If the host cannot be found, due to an invalid host_id, we first search for it, and store either the correct host ID, or set it to `NULL` to rerun `CREATE`.