### PR TITLE
Fix worker_tasks missing when getting all hardware

### DIFF
--- a/doni/api/hardware.py
+++ b/doni/api/hardware.py
@@ -182,7 +182,12 @@ def get_all():
     authorize("hardware:get", ctx)
     serialize = hardware_serializer(with_private_fields=True)
     return {
-        "hardware": [serialize(hw) for hw in Hardware.list(ctx)],
+        "hardware": [
+            serialize(
+                    hw,
+                    worker_tasks=WorkerTask.list_for_hardware(ctx, hw.uuid))
+            for hw in Hardware.list(ctx)
+        ],
     }
 
 

--- a/doni/tests/unit/api/test_hardware.py
+++ b/doni/tests/unit/api/test_hardware.py
@@ -75,6 +75,8 @@ def test_get_all_hardware(
     assert res.status_code == 200
     assert len(res.json["hardware"]) == 1
     _assert_hardware_json_ok(res.json["hardware"][0], _with_masked_sensitive_fields(hw))
+    for hardware in res.json["hardware"]:
+        _assert_hardware_has_workers(hardware)
     mock_authorize.assert_called_once_with("hardware:get", AnyContext())
 
 


### PR DESCRIPTION
Worker tasks were not passed into the serializer when getting all hardware, though they are being exposed for other routes. 