### PR TITLE
format capabilities as string for ironic

### DIFF
--- a/doni/driver/worker/ironic.py
+++ b/doni/driver/worker/ironic.py
@@ -215,6 +215,12 @@ class IronicWorker(BaseWorker):
         state_details: "dict" = None,
     ) -> "WorkerResult.Base":
         hw_props = hardware.properties
+
+        capabilities_list = []
+        for key, value in hw_props.get("baremetal_capabilities").items():
+            capabilities_list.append(f"{key}:{value}")
+        capabilities_string = ','.join(capabilities_list)
+
         desired_state = {
             "uuid": hardware.uuid,
             "name": hardware.name,
@@ -230,7 +236,7 @@ class IronicWorker(BaseWorker):
             },
             "resource_class": hw_props.get("baremetal_resource_class"),
             "properties": {
-                "capabilities": hw_props.get("baremetal_capabilities"),
+                "capabilities": capabilities_string,
                 "cpu_arch": hw_props.get("cpu_arch"),
             },
         }

--- a/doni/driver/worker/ironic.py
+++ b/doni/driver/worker/ironic.py
@@ -216,10 +216,12 @@ class IronicWorker(BaseWorker):
     ) -> "WorkerResult.Base":
         hw_props = hardware.properties
 
-        capabilities_list = []
-        for key, value in hw_props.get("baremetal_capabilities").items():
-            capabilities_list.append(f"{key}:{value}")
-        capabilities_string = ','.join(capabilities_list)
+        capabilities_string = ",".join(
+            [
+                f"{key}:{value}"
+                for key, value in hw_props.get("baremetal_capabilities").items()
+            ]
+        )
 
         desired_state = {
             "uuid": hardware.uuid,


### PR DESCRIPTION
Ironic requires the capabilities to be passed as a comma separated list
in the format '"key1:value1","key2:value2"'
https://github.com/openstack/ironic/blob/31c7469a91c58235b9200ce417ace57447bf23a7/ironic/drivers/utils.py#L150-L157