### PR TITLE
Set device profiles on Blazar

### DIFF
--- a/doni/driver/hardware_type/device.py
+++ b/doni/driver/hardware_type/device.py
@@ -86,6 +86,19 @@ COMMON_FIELDS = [
             "to enable the device to configure the device for the user's workload ."
         ),
     ),
+    WorkerField(
+        "device_profiles",
+        schema=args.array(args.STRING),
+        required=False,
+        private=False,
+        description=(
+            "A set of device profiles (representing a set of Linux resources that make "
+            "it possible to access an attached peripheral, such as a USB or GPU "
+            "device) currently supported on this device. Ideally this field is set via "
+            "an automated process that has verified the required devices for the "
+            "profile are all available."
+        ),
+    ),
 ]
 
 

--- a/doni/driver/worker/blazar/device.py
+++ b/doni/driver/worker/blazar/device.py
@@ -1,11 +1,15 @@
 from typing import TYPE_CHECKING
 
+from oslo_log import log as logging
+
 from doni.driver.hardware_type.device import MACHINE_METADATA
 from doni.driver.worker.blazar import BaseBlazarWorker
 from doni.worker import WorkerField
 
 if TYPE_CHECKING:
     from doni.objects.hardware import Hardware
+
+LOG = logging.getLogger(__name__)
 
 UNKNOWN_DEVICE = "unknown"
 
@@ -51,6 +55,17 @@ class BlazarDeviceWorker(BaseBlazarWorker):
                 "platform_version": "2",
             }
         )
+        for dp_name in hw_props.get("device_profiles", []):
+            if dp_name in device_dict:
+                LOG.warning(
+                    (
+                        f"Device profile {dp_name} already exists as a built-in property, "
+                        "refusing to set on Blazar!"
+                    )
+                )
+                continue
+            # Blazar stores all properties as strings
+            device_dict[dp_name] = "True"
         return device_dict
 
     @classmethod

--- a/doni/tests/unit/driver/worker/blazar/test_device.py
+++ b/doni/tests/unit/driver/worker/blazar/test_device.py
@@ -77,6 +77,7 @@ def get_fake_hardware(database: "utils.DBFixtures"):
         properties={
             "machine_name": "fake-machine_name",
             "contact_email": "fake-contact_email",
+            "device_profiles": ["fake-device_profile"],
         },
     )
     return Hardware(**db_hw)
@@ -104,6 +105,7 @@ def _get_devices_response(hw_list) -> dict:
             "device_driver": "k8s",
             "machine_name": "fake-machine_name",
             "device_name": UNKNOWN_DEVICE,
+            "fake-device_profile": "True",
         }
         response_dict["devices"].append(hw_dict)
     return response_dict
@@ -277,6 +279,7 @@ def test_no_updates_to_device(
                 "vendor": UNKNOWN_DEVICE,
                 "model": UNKNOWN_DEVICE,
                 "platform_version": "2",
+                "fake-device_profile": "True",
             },
         )
         if device_response:


### PR DESCRIPTION
This adds a device_profiles property for the device hardware type,
which is a list. Each profile is expanded to a separate key on
Blazar, with a value of "True". Currently we don't have a way to
unset these properties, so they will never be pruned later :(