### PR TITLE
set name instead of hypervisor_hostname

### DIFF
--- a/doni/driver/worker/blazar/physical_host.py
+++ b/doni/driver/worker/blazar/physical_host.py
@@ -30,7 +30,7 @@ class BlazarPhysicalHostWorker(BaseBlazarWorker):
 
     resource_type = "host"
     resource_path = "/os-hosts"
-    resource_pk = "hypervisor_hostname"
+    resource_pk = "name"
 
     fields = BaseBlazarWorker.fields + [
         WorkerField(


### PR DESCRIPTION
blazar requires id or name when creating a new host object, and
uses these to look up the hypervisor_hostname and other info from nova

If not specified, blazar will return a 403.