### PR TITLE
Wip/fix doni sync

### DIFF
--- a/doni/driver/util.py
+++ b/doni/driver/util.py
@@ -1,4 +1,3 @@
-from textwrap import shorten
 import typing
 
 from keystoneauth1 import exceptions as kaexception
@@ -57,7 +56,7 @@ def ks_service_requestor(
             if callable(parse_error):
                 error_message = parse_error(resp.text)
             else:
-                error_message = shorten(resp.text, width=50)
+                error_message = resp.text
             raise KeystoneServiceAPIError(
                 service=name, code=resp.status_code, text=error_message
             )
@@ -67,7 +66,7 @@ def ks_service_requestor(
             return resp.json() if resp.text else None
         except Exception:
             raise KeystoneServiceMalformedResponse(
-                service=name, text=shorten(resp.text, width=50)
+                service=name, text=resp.text
             )
 
     return _request

--- a/doni/driver/worker/blazar/physical_host.py
+++ b/doni/driver/worker/blazar/physical_host.py
@@ -54,7 +54,7 @@ class BlazarPhysicalHostWorker(BaseBlazarWorker):
     def expected_state(self, hardware: "Hardware", host_dict: "dict") -> dict:
         hw_props = hardware.properties
         placement_props = hw_props.get("placement", {})
-        host_dict.update({"uid": hardware.uuid, "node_name": hardware.name})
+        host_dict.update({"node_name": hardware.name})
 
         # FIXME(jason): Currently Blazar does not allow deleting extra capabilities,
         # and setting to None triggers errors in Blazar during create/update.


### PR DESCRIPTION
this PR fixes two issues with Doni synchronization, but should probably be broken up.

* utility fix: don't truncate error messages in the logs
* ironic: set nodes to manageable before attempting to update ports
* blazar: use `name` as unique identifier, don't set `uid` or `hypervisor_hostname`