### PR TITLE
Include error details for tasks

### DIFF
--- a/doni/worker/__init__.py
+++ b/doni/worker/__init__.py
@@ -44,8 +44,9 @@ class WorkerResult:
 
         def __init__(self, payload: dict = None, reason: str = None):
             self.reason = reason
+            if payload is None:
+                payload = {}
             if self.reason is not None:
-                payload = payload or {}
                 payload[self.DEFER_REASON_DETAIL] = self.reason
             super().__init__(payload)
 


### PR DESCRIPTION
This fixes a few issues with error reporting, and also fixes an issue with deferred task execution that I found while fixing error reporting.

First, we rearrange the logic in the process task loop so that it always saves the task. This should help in the event of hitting an exception in the "else" block that existed prior.

Second, we use the traceback.TracebackException to print the stack from the exception object. These will be printed when debug mode is enabled.

Finally, I added a test to catch an issue w/ the Defer worker result. We were not looping over the payload items(). I added a test that can be used as a template for future tests; it involves stubbing the "process" function on the FakeWorker. The FakeWorker is by default used in all the tests.