### PR TITLE
report version in format that keystoneauth1 expects

### DIFF
--- a/doni/api/root.py
+++ b/doni/api/root.py
@@ -11,6 +11,10 @@ def info():
             "Doni is an OpenStack project for managing hardware "
             "enrollment and availability."
         ),
-        "default_version": "1.0",
-        "versions": ["1.0"],
+        "versions": [
+            {
+                "id": "1.0",
+                "status": "CURRENT"
+            }
+        ],
     }


### PR DESCRIPTION
keystoneauth1 version discovery fails when the `version` key  is not an array of dicts.