### PR TITLE
Raspberry pi5 support (#139)

### DIFF
--- a/doni/driver/hardware_type/device.py
+++ b/doni/driver/hardware_type/device.py
@@ -10,6 +10,7 @@ SUPPORTED_MACHINE_NAMES = [
     "jetson-xavier-nx-emmc",
     "raspberrypi3-64",
     "raspberrypi4-64",
+    "raspberrypi5",
     "coral-dev",
 ]
 MACHINE_METADATA = {
@@ -32,6 +33,11 @@ MACHINE_METADATA = {
         "full_name": "Raspberry Pi 4 (using 64bit OS)",
         "vendor": "Raspberry Pi",
         "model": "4",
+    },
+    "raspberrypi5": {
+        "full_name": "Raspberry Pi 5 (using 64bit OS)",
+        "vendor": "Raspberry Pi",
+        "model": "5",
     },
     "coral-dev": {
         "full_name": "Google Coral Dev Board",


### PR DESCRIPTION
* added raspberrypi5 as supported machine type

Needs to modify doni.conf to add fleet mapping for raspberrypi5 to balena fleet

(cherry picked from commit 8893a96ec2d29f2347853ea7de922179e6d37cb4)