### PR TITLE
Make k8s bootstrap token a private field within the doni API (#137)

### DIFF
--- a/doni/driver/hardware_type/device.py
+++ b/doni/driver/hardware_type/device.py
@@ -90,7 +90,7 @@ COMMON_FIELDS = [
         "k8s_bootstrap_token",
         schema=args.STRING,
         required=False,
-        private=False,
+        private=True,
         description=(
             "A token used to join the device to a k3s cluster during bootstrap."
         ),


### PR DESCRIPTION
(cherry picked from commit b976bc01d9e61c89ca18486e0008e146b9127a8f)