### PR TITLE
feat: fetch observed_state from balena worker

### DIFF
--- a/doni/api/hardware.py
+++ b/doni/api/hardware.py
@@ -24,6 +24,7 @@ WORKER_TASK_DEFAULT_FIELDS = (
     "worker_type",
     "state",
     "state_details",
+    "observed_state",
 )
 
 HARDWARE_ENROLL_SCHEMA = {

--- a/doni/db/alembic/versions/e58738bfc58e_add_observed_state_to_worker_task.py
+++ b/doni/db/alembic/versions/e58738bfc58e_add_observed_state_to_worker_task.py
@@ -1,0 +1,28 @@
+"""add observed_state to worker_task
+
+Revision ID: e58738bfc58e
+Revises: 868606f1faff
+Create Date: 2026-05-11 15:05:22.211899
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from oslo_db.sqlalchemy import types as oslo_sa_types
+
+
+# revision identifiers, used by Alembic.
+revision = "e58738bfc58e"
+down_revision = "868606f1faff"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "worker_task",
+        sa.Column("observed_state", oslo_sa_types.JsonEncodedDict(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("worker_task", "observed_state")

--- a/doni/db/api.py
+++ b/doni/db/api.py
@@ -321,6 +321,15 @@ class Connection(object):
         )
         return query.all()
 
+    def get_worker_tasks_by_type(
+        self, worker_type: str
+    ) -> "list[models.WorkerTask]":
+        query = (
+            model_query(models.WorkerTask)
+            .filter(models.WorkerTask.worker_type == worker_type)
+        )
+        return query.all()
+
     def get_worker_tasks_for_hardware(
         self, hardware_uuids: "list[str]"
     ) -> "dict[str, list[models.WorkerTask]]":

--- a/doni/db/models.py
+++ b/doni/db/models.py
@@ -80,6 +80,7 @@ class WorkerTask(models.SoftDeleteMixin, Base):
     worker_type = Column(String(64))
     state = Column(String(15))
     state_details = Column(db_types.JsonEncodedDict)
+    observed_state = Column(db_types.JsonEncodedDict)
 
 
 class AvailabilityWindow(Base):

--- a/doni/driver/worker/balena.py
+++ b/doni/driver/worker/balena.py
@@ -3,11 +3,13 @@ from typing import TYPE_CHECKING
 
 from oslo_config.cfg import DictOpt, StrOpt
 from oslo_log import log
+from futurist import periodics
 
 from doni.api import utils as api_utils
 from doni.common import args
 from doni.conf import CONF
 from doni.driver.worker.base import BaseWorker
+from doni.objects.worker_task import WorkerTask
 from doni.worker import WorkerField, WorkerResult
 
 if TYPE_CHECKING:
@@ -103,7 +105,6 @@ class BalenaWorker(BaseWorker):
                     "device_id": None,
                     "device_api_key": None,
                     "fleet_id": None,
-                    "last_seen": None,
                 }
             )
 
@@ -144,14 +145,8 @@ class BalenaWorker(BaseWorker):
         # useful to track for some operations
         state_details["device_id"] = balena_device["id"]
         state_details["fleet_id"] = balena_device["belongs_to__application"].get("__id")
-        state_details["last_seen"] = (
-            api_utils.format_date(datetime.now(tz=timezone.utc))
-            if balena_device["is_online"]
-            else balena_device["last_connectivity_event"]
-        )
 
         return WorkerResult.Success(state_details)
-
 
     def _set_device_type(self, balena_adapter, device_id, device_type):
         # This function isn't available in the SDK but we can implement
@@ -168,8 +163,7 @@ class BalenaWorker(BaseWorker):
         return {
             device_type["slug"]: device_type["id"]
             for device_type in balena_adapter.models.device_type.get_all()
-            }
-
+        }
 
     def _register_device(self, balena, hardware: "Hardware"):
         from balena.exceptions import DeviceNotFound
@@ -237,3 +231,49 @@ class BalenaWorker(BaseWorker):
         elif existing["value"] != value:
             device_vars.update(existing["id"], value)
             LOG.info(f"Updated device env var {key} for {hardware_uuid}")
+
+    @periodics.periodic(spacing=300, run_immediately=True)
+    def fetch_observed_state(self, context):
+        """Get current info from balena.
+
+        Executed periodically. Gets current info from balena API for all
+        devices, then updates the `observed_state` field of each balena worker
+        task.
+        """
+
+        # Look up current info for all balena devices in managed fleets.
+        balena_devices_by_uuid = {}
+        balena = _get_balena_sdk()
+        for fleet_name in set(CONF.balena.device_fleet_mapping.values()):
+            LOG.debug(f"Fetching devices for {fleet_name}")
+            devices_in_fleet = balena.models.device.get_all_by_application(fleet_name)
+            for dev in devices_in_fleet or []:
+                LOG.debug(f"Got {dev}")
+                device_uuid = dev["uuid"]
+                balena_devices_by_uuid[device_uuid] = dev
+
+        last_fetched = api_utils.format_date(datetime.now(tz=timezone.utc))
+        balena_tasks = WorkerTask.list_by_type(context, "balena")
+        for task in balena_tasks:
+            balena_uuid = self._to_device_id(task.hardware_uuid)
+            dev = balena_devices_by_uuid.get(balena_uuid)
+            if not dev:
+                # either the device is missing from balena, or the fetch failed.
+                # continue means that db shows state as of last fetched_at
+                # TODO: if we can prove missing from balena, clear the data
+                continue
+
+            # build observed state from balena device info
+            observed_state = {
+                "last_fetched": last_fetched,
+                "status": dev.get("status"),
+                "is_online": dev.get("is_online"),
+                "last_connectivity_event": dev.get("last_connectivity_event"),
+            }
+            try:
+                task.observed_state = observed_state
+                task.save()
+            except Exception:
+                LOG.exception(
+                    f"Failed to update observed state for task:{task.uuid} device:{balena_uuid}"
+                )

--- a/doni/objects/worker_task.py
+++ b/doni/objects/worker_task.py
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
 @base.DoniObjectRegistry.register
 class WorkerTask(base.DoniObject):
     # Version 1.0: Initial version
-    VERSION = "1.0"
+    # Version 1.1: Added observed_state
+    VERSION = "1.1"
 
     dbapi = db_api.get_instance()
 
@@ -23,6 +24,7 @@ class WorkerTask(base.DoniObject):
         "worker_type": object_fields.StringField(),
         "state": object_fields.WorkerStateField(),
         "state_details": object_fields.FlexibleDictField(),
+        "observed_state": object_fields.FlexibleDictField(nullable=True),
     }
 
     @property
@@ -59,6 +61,14 @@ class WorkerTask(base.DoniObject):
     def list_pending(cls, context: "RequestContext") -> "list[WorkerTask]":
         db_workers = cls.dbapi.get_worker_tasks_in_state(WorkerState.PENDING)
         return cls._from_db_object_list(context, db_workers)
+
+    @classmethod
+    def list_by_type(
+        cls, context: "RequestContext", worker_type: str
+    ) -> "list[WorkerTask]":
+        return cls._from_db_object_list(
+            context, cls.dbapi.get_worker_tasks_by_type(worker_type)
+        )
 
     @classmethod
     def list_for_hardware(

--- a/doni/tests/unit/driver/worker/test_balena.py
+++ b/doni/tests/unit/driver/worker/test_balena.py
@@ -7,6 +7,7 @@ from doni.driver.worker.balena import BalenaWorker
 from doni.common.context import RequestContext
 from doni.tests.unit import utils
 from doni.objects.hardware import Hardware
+from doni.objects.worker_task import WorkerTask
 import dataclasses
 
 
@@ -168,3 +169,49 @@ def test_sync_device_var(
     assert fake_balena.models.environment_variables.device.get_all.call_count==device_get_count
     assert fake_balena.models.environment_variables.device.create.call_count==device_create_count
     assert fake_balena.models.environment_variables.device.update.call_count==device_update_count
+
+
+def test_fetch_observed_state(
+    mocker,
+    test_config,
+    admin_context: "RequestContext",
+    balena_worker: "BalenaWorker",
+    database: "utils.DBFixtures",
+):
+    """Happy path: observed_state is written from balena data for each task."""
+    test_config.config(
+        device_fleet_mapping={TEST_BALENA_DEVICE_TYPE: "test-fleet"},
+        group="balena",
+    )
+    mocker.patch(
+        "doni.driver.worker.balena.api_utils.format_date",
+        return_value="2026-05-12T17:00:00+00:00",
+    )
+
+    fake_hw = get_fake_hardware(database)
+    balena_device_uuid = balena_worker._to_device_id(fake_hw.uuid)
+
+    fake_balena = mock.MagicMock(Balena())
+    fake_balena.models.device.get_all_by_application.return_value = [
+        {
+            "uuid": balena_device_uuid,
+            "status": "Idle",
+            "is_online": True,
+            "last_connectivity_event": "2026-05-12T17:00:00Z",
+        },
+    ]
+    mocker.patch(
+        "doni.driver.worker.balena._get_balena_sdk"
+    ).return_value = fake_balena
+
+    balena_worker.fetch_observed_state(admin_context)
+
+    fake_balena.models.device.get_all_by_application.assert_called_once_with("test-fleet")
+    tasks = WorkerTask.list_by_type(admin_context, "balena")
+    assert len(tasks) == 1
+    assert tasks[0].observed_state == {
+        "last_fetched": "2026-05-12T17:00:00+00:00",
+        "status": "Idle",
+        "is_online": True,
+        "last_connectivity_event": "2026-05-12T17:00:00Z",
+    }

--- a/doni/tests/unit/objects/test_worker_task.py
+++ b/doni/tests/unit/objects/test_worker_task.py
@@ -63,3 +63,29 @@ def test_save_invalid_transition(admin_context, database: "utils.DBFixtures"):
     with pytest.raises(ValueError):
         # Cannot move from PENDING to STEADY
         task.state = WorkerState.STEADY
+
+
+def test_save_only_writes_changed_fields(admin_context, database: "utils.DBFixtures"):
+    """Two instances of the same task writing disjoint fields must not clobber.
+
+    Mirrors the race between _process_task (writes state/state_details) and
+    the balena fetch_observed_state periodic (writes observed_state).
+    obj_get_changes() should scope each UPDATE to only the locally-dirty fields.
+    """
+    hw = database.add_hardware()
+    task_a = WorkerTask.list_for_hardware(admin_context, hw["uuid"])[0]
+    task_b = WorkerTask.list_for_hardware(admin_context, hw["uuid"])[0]
+
+    task_a.state = WorkerState.IN_PROGRESS
+    task_a.state_details = {"progress": "running"}
+    task_a.save()
+
+    # B's in-memory state/state_details are now stale, but its save() should
+    # only emit an UPDATE for observed_state.
+    task_b.observed_state = {"is_online": True}
+    task_b.save()
+
+    fresh = WorkerTask.list_for_hardware(admin_context, hw["uuid"])[0]
+    assert fresh.state == WorkerState.IN_PROGRESS
+    assert fresh.state_details == {"progress": "running"}
+    assert fresh.observed_state == {"is_online": True}


### PR DESCRIPTION
to prevent collisions, periodic fetch of observed state will write to its own json column, separate from state_details column which "process" writes to.

Most data is straight from balena, but add a timestamp for the latest successful fetch so that clients can identify stale data.

(cherry picked from commit dfaaa717a789d5a4e19660ffc190a97fef01d98c)